### PR TITLE
enable CAN communication

### DIFF
--- a/zero/meta-mcp2517fd/conf/layer.conf
+++ b/zero/meta-mcp2517fd/conf/layer.conf
@@ -11,6 +11,7 @@ BBFILE_PRIORITY_mcp2517fd = "6"
 LAYERDEPENDS_mcp2517fd = "raspberrypi"
 LAYERSERIES_COMPAT_mcp2517fd = "kirkstone"
 
+IMAGE_INSTALL:append = " kernel-module-can-dev kernel-module-can-raw kernel-module-spi-bcm2835 kernel-module-mcp251xfd"
 KERNEL_DEVICETREE:append = " overlays/mcp2517fd.dtbo"
 RPI_EXTRA_CONFIG:append = "\
 dtparam=spi=on \n \

--- a/zero/meta-mcp2517fd/conf/layer.conf
+++ b/zero/meta-mcp2517fd/conf/layer.conf
@@ -1,0 +1,18 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-devicetree/linux-raspberrypi_%.bbappend"
+
+BBFILE_COLLECTIONS += "mcp2517fd"
+BBFILE_PATTERN_mcp2517fd = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mcp2517fd = "6"
+
+LAYERDEPENDS_mcp2517fd = "raspberrypi"
+LAYERSERIES_COMPAT_mcp2517fd = "kirkstone"
+
+KERNEL_DEVICETREE:append = " overlays/mcp2517fd.dtbo"
+RPI_EXTRA_CONFIG:append = "\
+dtparam=spi=on \n \
+dtoverlay=mcp2517fd \n \
+"

--- a/zero/meta-mcp2517fd/recipes-devicetree/files/mcp2517fd-overlay.dts
+++ b/zero/meta-mcp2517fd/recipes-devicetree/files/mcp2517fd-overlay.dts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 KantaTamura <tkanta496@gmail.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/*
+ * Device tree overlay for mcp2517fd/can0 on spi0.0
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "brcm,bcm2835";
+
+    /* enable spi for spi0.0 */
+    fragment@0 {
+        target = <&spi0>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+
+    /* disable spi-dev for spi0.0 */
+    fragment@1 {
+        target = <&spidev0>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    /* the interrupt pin of mcp2517fd */
+    fragment@2 {
+        target = <&gpio>;
+        __overlay__ {
+            mcp2517fd_int_pin: mcp2517fd_int_pin {
+                brcm,pins = <25>;       // use GPIO25 for interrupt pin
+                brcm,function = <0>;    // BCM2835_FSEL_GPIO_IN
+            };
+        };
+    };
+
+    /* the clock/oscillator of mcp2517fd */
+    fragment@3 {
+        target-path = "/clocks";
+        __overlay__ {
+            /* external oscillator of mcp2517fd on SPI0.0 */
+            clk_mcp2517fd_osc: clk_mcp2517fd_osc {
+                compatible = "fixed-clock";
+                #clock-cells = <0>;
+                clock-frequency  = <20000000>;  // use 20MHz oscillator
+            };
+        };
+    };
+
+    /* the spi config of the can-controller itself binding everything together */
+    fragment@4 {
+        target = <&spi0>;
+        __overlay__ {
+            /* needed to avoid dtc warning */
+            #address-cells = <1>;
+            #size-cells = <0>;
+            can0: mcp2517fd@0 {
+                reg = <0>;
+                compatible = "microchip,mcp2517fd";
+                pinctrl-names = "default";
+                pinctrl-0 = <&mcp2517fd_int_pin>;
+                spi-max-frequency = <20000000>;     // up to 20MHz SPI clock speed on mcp2517fd
+                interrupt-parent = <&gpio>;
+                interrupts = <25 8>;                // IRQ_TYPE_LEVEL_LOW : active low
+                clocks = <&clk_mcp2517fd_osc>;
+            };
+        };
+    };
+
+    __overrides__ {
+        oscillator = <&clk_mcp2517fd_osc>,"clock-frequency:0";
+        spimaxfrequency = <&can0>,"spi-max-frequency:0";
+        interrupt = <&mcp2517fd_int_pin>,"brcm,pins:0",<&can0>,"interrupts:0";
+    };
+};

--- a/zero/meta-mcp2517fd/recipes-devicetree/linux-raspberrypi_%.bbappend
+++ b/zero/meta-mcp2517fd/recipes-devicetree/linux-raspberrypi_%.bbappend
@@ -1,0 +1,5 @@
+SRC_URI += "file://mcp2517fd-overlay.dts;subdir=git/arch/${ARCH}/boot/dts/overlays"
+
+FILESEXTRAPATHS:append := "${THISDIR}/files:"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/zero/meta-scsat1-rpi/conf/bblayers.conf.sample
+++ b/zero/meta-scsat1-rpi/conf/bblayers.conf.sample
@@ -9,4 +9,5 @@ BBLAYERS ?= " \
   ##OEROOT##/meta \
   ##OEROOT##/../meta-raspberrypi \
   ##OEROOT##/../meta-scsat1-rpi \
+  ##OEROOT##/../meta-mcp2517fd \
   "


### PR DESCRIPTION
## 変更内容
- mcp2517fd用のデバイスツリーを追加
- CAN通信を行うためのカーネルモジュールの追加

## 変更詳細

### device-tree

作成した `mcp2517fd-overlay.dts` をカーネルのデバイスツリービルドフォルダに追加し，一緒にビルドするようにした

### kernel-module

MCP2517FDを用いたCAN通信を行うための最小限のカーネルモジュールをインストールするようにした
- spi_bcm2835 : raspberry pi zero 2 w で使用できるSPI通信用のモジュール
- can_dev : CAN Network Device Driver Interface
- can_raw : これが無いとCAN通信時に `address family not supported by protocol` と表示される
- mcp251xfd : MCP2517FD用のドライバ

## CAN通信を試す方法

### root login

'local.conf'に次の内容を加える

```
EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
```

### install can-utils

`doc/zero/build.md` の内容に加えて，[meta-openembedded](https://github.com/openembedded/meta-openembedded) の `meta-oe` 追加し，'local.conf' に次の内容を加える．

```
IMAGE_INSTALL:append = " can-utils"
```

### candump & cangen

> ***note***
> can通信する相手がいないと `error-passive` となり，通信できない

rootログイン後下記のコマンドを試す
```
$ ip link set can0 up type can bitrate 1000000
$ candump can0 &
$ cangen can0
```