### PR TITLE
doc/zero: Fix typo on build.md

### DIFF
--- a/doc/zero/build.md
+++ b/doc/zero/build.md
@@ -30,7 +30,7 @@ $ git clone https://github.com/spacecubics/scsat1-rpi
 $ cd scsat1-rpi/zero
 $ git clone -b kirkstone git://git.yoctoproject.org/meta-raspberrypi
 $ git clone -b kirkstone git://git.yoctoproject.org/poky
-$ TEMPLATECONF=$(readlink -f ./meta-scsat-rpi/conf) source ./poky/oe-init-build-env
+$ TEMPLATECONF=$(readlink -f ./meta-scsat1-rpi/conf) source ./poky/oe-init-build-env
 $ bitbake core-image-minimal
 ```
 


### PR DESCRIPTION
This commit fixes typo on build procedure.

 meta-scsat-rpi -> meta-scsat1-rpi

Originally there was a typo in the procedure on Notion, but it has already been fixed.