### PR TITLE
pico: Add dts overlay for change console to UART1

### DIFF
--- a/pico/app.overlay
+++ b/pico/app.overlay
@@ -1,0 +1,26 @@
+/ {
+	chosen {
+		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
+	};
+};
+
+&uart1 {
+	current-speed = <115200>;
+	status = "okay";
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+};
+
+
+&pinctrl {
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_P8>;
+		};
+		group2 {
+			pinmux = <UART1_RX_P9>;
+			input-enable;
+		};
+	};
+};


### PR DESCRIPTION
Raspberry Pi Pico on SC-Sat1 use UART0 for communicate to Raspberry Pi Zero 2 W.
However default dts use UART0 for console.

This commit changes default console port from uart0 to uart1.