### PR TITLE
install libcsp.so

### DIFF
--- a/zero/meta-libcsp/conf/layer.conf
+++ b/zero/meta-libcsp/conf/layer.conf
@@ -1,0 +1,12 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-libcsp/libcsp_*.bb"
+
+BBFILE_COLLECTIONS += "libcsp"
+BBFILE_PATTERN_libcsp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_libcsp = "6"
+
+LAYERDEPENDS_libcsp = "core"
+LAYERSERIES_COMPAT_libcsp = "kirkstone"

--- a/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
+++ b/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
@@ -1,0 +1,20 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2915dc85ab8fd26629e560d023ef175c"
+
+SRCREV = "${AUTOREV}"
+SRCBRANCH = "develop"
+SRC_URI = "git://github.com/libcsp/libcsp.git;protocol=https;branch=${SRCBRANCH};"
+
+PACKAGES = "${PN} ${PN}-dbg ${PN}-dev"
+
+FILES:${PN}-dbg += "${libdir}/.debug"
+FILES:${PN}     += "${libdir}/libcsp.so"
+FILES:${PN}-dev += "${includedir}/csp"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+do_install:append() {
+    chmod 644 ${D}${libdir}/libcsp.so
+}

--- a/zero/meta-scsat1-rpi/conf/bblayers.conf.sample
+++ b/zero/meta-scsat1-rpi/conf/bblayers.conf.sample
@@ -10,4 +10,5 @@ BBLAYERS ?= " \
   ##OEROOT##/../meta-raspberrypi \
   ##OEROOT##/../meta-scsat1-rpi \
   ##OEROOT##/../meta-mcp2517fd \
+  ##OEROOT##/../meta-libcsp \
   "


### PR DESCRIPTION
cspで通信するためのlibcsp.soをインストールするレシピを追加した

おそらくlibcsp.soを使用するレシピがないため，`bitbake core-image-minimal`ではビルドされないので，下記のコマンドでレシピ単体をビルドできる
```
$ bitbake libcsp
```

[libcsp](https://github.com/libcsp/libcsp)のdevelopブランチを用いてcmakeでビルドし，CMakeList.txtにはinstall関連がなかったため，レシピ内で`do_install()`を記述している