### PR TITLE
.github: workflows: Remove rebasing

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -20,11 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Git (pull request)
-        if: ${{ github.base_ref }}
-        env:
-          BASE_REF: ${{ github.base_ref }}
         run: |
-          git rebase origin/${BASE_REF}
           git checkout -b this_pr
 
       - name: Run gitlint


### PR DESCRIPTION
To check with gitlint, we don't need to rebase the PR on the main.

When the PR is not from the current main, this rebase will create commits with commiter information from the instance this Action is running, which obviously don't have a proper DCO, and the check fails.