### PR TITLE
enable socketcan on libcsp

### DIFF
--- a/doc/zero/build.md
+++ b/doc/zero/build.md
@@ -30,6 +30,7 @@ $ git clone https://github.com/spacecubics/scsat1-rpi
 $ cd scsat1-rpi/zero
 $ git clone -b kirkstone git://git.yoctoproject.org/meta-raspberrypi
 $ git clone -b kirkstone git://git.yoctoproject.org/poky
+$ git clone -b kirkstone git://git.openembedded.org/meta-openembedded
 $ TEMPLATECONF=$(readlink -f ./meta-scsat1-rpi/conf) source ./poky/oe-init-build-env
 $ bitbake core-image-minimal
 ```

--- a/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
+++ b/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
@@ -5,6 +5,8 @@ SRCREV = "${AUTOREV}"
 SRCBRANCH = "develop"
 SRC_URI = "git://github.com/libcsp/libcsp.git;protocol=https;branch=${SRCBRANCH};"
 
+DEPENDS += "libsocketcan"
+
 PACKAGES = "${PN} ${PN}-dbg ${PN}-dev"
 
 FILES:${PN}-dbg += "${libdir}/.debug"
@@ -13,7 +15,7 @@ FILES:${PN}-dev += "${includedir}/csp"
 
 S = "${WORKDIR}/git"
 
-inherit cmake
+inherit cmake pkgconfig
 
 do_install:append() {
     chmod 644 ${D}${libdir}/libcsp.so

--- a/zero/meta-scsat1-rpi/conf/bblayers.conf.sample
+++ b/zero/meta-scsat1-rpi/conf/bblayers.conf.sample
@@ -11,4 +11,5 @@ BBLAYERS ?= " \
   ##OEROOT##/../meta-scsat1-rpi \
   ##OEROOT##/../meta-mcp2517fd \
   ##OEROOT##/../meta-libcsp \
+  ##OEROOT##/../meta-openembedded/meta-oe \
   "


### PR DESCRIPTION
libcspでsocketcanを使えるように共有ライブラリをリンクするように変更した．

使用するレシピがmeta-oeにあるので，クローンすることをドキュメントに追記した．