### PR TITLE
zero Add: create .txt file with metadata

### DIFF
--- a/zero/rpios/.gitignore
+++ b/zero/rpios/.gitignore
@@ -1,3 +1,4 @@
 *.dng
 *.jpg
 __pycache__
+*.txt

--- a/zero/rpios/exifrw.py
+++ b/zero/rpios/exifrw.py
@@ -1,0 +1,99 @@
+import pyexiv2
+import os
+import sys
+from io import StringIO
+
+IMG_PATH = "Product\ImageJPG\image1.jpg"
+
+
+def exif_read(path=""):
+    with pyexiv2.Image(path) as img:
+        data = img.read_exif()
+        print("----------------")
+        print(type(data))
+        for key, value in data.items():
+            print(f'{key}: {value}')
+        print("----------------")
+
+
+def xmp_read(path=""):
+    with pyexiv2.Image(path) as img:
+        data = img.read_xmp()
+        print("----------------")
+        print(type(data))
+        for key, value in data.items():
+            print(f'{key}: {value}')
+        print("----------------")
+
+
+def xmp_get_dict(path=""):
+    with pyexiv2.Image(path) as img:
+        data = img.read_xmp()
+        return data
+
+
+def xmp_write(path="", tag="", data=""):
+    pyexiv2.registerNs("namespace for scsat1-rpi","sc1")
+    img = pyexiv2.Image(path)
+    if tag == "":
+        pass
+    else:
+        tag = "Xmp.sc1." + tag
+        img.modify_xmp({tag: data})
+
+
+def xmp_delete(path=""):
+    key = input("Are you sure to delete all xmp data? (y/n): ")
+    if key == "y":
+        with pyexiv2.Image(path) as img:
+            img.clear_xmp()
+    else:
+        pass
+
+
+def capture_output(func, *args, **kwargs):
+    """Utility function to capture print output from a function."""
+    old_stdout = sys.stdout
+    sys.stdout = new_stdout = StringIO()
+    try:
+        func(*args, **kwargs)
+    finally:
+        sys.stdout = old_stdout
+    return new_stdout.getvalue()
+
+def meta_save(image_path):
+    """Reads metadata from the image and saves it to a .txt file."""
+    # Capturing the output from the exif_read and xmp_read functions
+    exif_output = capture_output(exif_read, image_path)
+    xmp_output = capture_output(xmp_read, image_path)
+
+    # Combining both outputs
+    full_output = exif_output + "\n" + xmp_output
+
+    # Generating the output file name
+    output_filename = os.path.splitext(image_path)[0] + ".txt"
+
+    # Writing the combined output to the .txt file
+    with open(output_filename, "w") as file:
+        file.write(full_output)
+
+    return f"Metadata saved to {output_filename}"
+
+
+def meta_save_directory(directory_path="./ImageJPG"):
+    """Reads metadata from all .jpg files in the directory and saves it to .txt files."""
+    for root, dirs, files in os.walk(directory_path):
+        for file in files:
+            if file.lower().endswith('.jpg'):
+                file_path = os.path.join(root, file)
+                meta_save(file_path)
+    return f"Metadata saved for all .jpg files in {directory_path}"
+
+
+
+if __name__ == "__main__":
+    # xmp_delete(IMG_PATH)
+    # exif_read(IMG_PATH)
+    # xmp_read(IMG_PATH)
+    # xmp_write(IMG_PATH, "BinalizedWhiteRate", "100"); xmp_read(IMG_PATH)
+    meta_save_directory()

--- a/zero/rpios/scsat1-cam
+++ b/zero/rpios/scsat1-cam
@@ -18,8 +18,8 @@ while True:
     # If received 'p', return 'p'
     if data == b'p':
         sock.sendto(data, addr)
-    # Send 'e' for everything else
 
+    # if received 'c', capture dng and jpg and save to each directory
     elif data == b'c':
         try:
             capture.capture_dng_jpg(file.get_name())
@@ -28,8 +28,10 @@ while True:
             print("Capture Error")
             print(e)
         sock.sendto(b'c', addr)
+
+    # Send 'e' for everything else
     else:
-        sock.sendto('e', addr)
+        sock.sendto(b'e', addr)
 
 # Close the socket. Since there is a closing program, it seems
 # unlikely that the ground station will be automatically closed

--- a/zero/rpios/scsat1-cam
+++ b/zero/rpios/scsat1-cam
@@ -3,6 +3,7 @@
 import socket
 import capture
 import file
+import exifrw
 
 # Set the UDP port number
 PORT = 12345
@@ -28,6 +29,16 @@ while True:
             print("Capture Error")
             print(e)
         sock.sendto(b'c', addr)
+
+    # if received 'm', save metadata to file
+    elif data == b'm':
+        try:
+            exifrw.meta_save_directory()
+        except Exception as e:
+            sock.sendto(b'e', addr)
+            print('Save metadata Error')
+            print(e)
+        sock.sendto(b'm', addr)
 
     # Send 'e' for everything else
     else:


### PR DESCRIPTION
地上局から`b'm'`を送信したときに，`./ImageJPG/`内にある
`.jpg`ファイルのメタデータを書き込んだ同名の`.txt`ファイル
を生成する機能を`./scsat1-cam`に追加した．

> 例）
> (実行前)
> ```
> ~/ImageJPG $ ls
> image1.jpg image2.jpg
> ```
> 
> (実行後)
> ```
> ~/ImageJPG $ ls
> image1.jpg image1.txt image2.jpg image2.txt
> ```


処理が正常に行われたときには`b'm'`が返され，
エラーが生じたときには`b'e'`が返される．

現在エラー内容は`print()`を用いて表示されるが，
デバッグ用途であるため後に取り除く予定．