### PR TITLE
fixed a few details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /zero/build*
 /zero/poky/
 /zero/meta-raspberrypi/
+/zero/meta-openembedded/

--- a/doc/zero/build.md
+++ b/doc/zero/build.md
@@ -20,10 +20,6 @@ https://docs.yoctoproject.org/ref-manual/system-requirements.html#required-packa
 
 # :hammer: build
 
-> **Warning**
-> currently only works with GCC 12  
-> https://github.com/rpm-software-management/libdnf/issues/1558
-
 run in bash or zsh
 ```shell
 $ git clone https://github.com/spacecubics/scsat1-rpi


### PR DESCRIPTION
いくつかの細かい修正を行いました。

- git cloneするmeta-openembeddedディレクトリをgitignoreに追加
- GCC 13でもkirkstoneをビルドできるようになっていたので注意文を削除

参考
https://github.com/yoctoproject/poky/commit/4bf9d11c4b09e4ff7fd140530dd7e43aa7ee6312