### PR TITLE
Adding systemd to handle CSP packets

### DIFF
--- a/zero/meta-csp/conf/layer.conf
+++ b/zero/meta-csp/conf/layer.conf
@@ -1,0 +1,14 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-cspd/csp-handler/csp-handler_*.bb"
+
+BBFILE_COLLECTIONS += "csp"
+BBFILE_PATTERN_csp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_csp = "6"
+
+LAYERDEPENDS_csp = "libcsp"
+LAYERSERIES_COMPAT_csp = "kirkstone"
+
+IMAGE_INSTALL:append = " csp-handler"

--- a/zero/meta-csp/conf/layer.conf
+++ b/zero/meta-csp/conf/layer.conf
@@ -2,7 +2,8 @@
 BBPATH .= ":${LAYERDIR}"
 
 # We have recipes-* directories, add to BBFILES
-BBFILES += "${LAYERDIR}/recipes-cspd/csp-handler/csp-handler_*.bb"
+BBFILES += "${LAYERDIR}/recipes-cspd/csp-handler/csp-handler_*.bb \
+            ${LAYERDIR}/recipes-cspd/systemd/cspd_*.bb"
 
 BBFILE_COLLECTIONS += "csp"
 BBFILE_PATTERN_csp = "^${LAYERDIR}/"
@@ -11,4 +12,4 @@ BBFILE_PRIORITY_csp = "6"
 LAYERDEPENDS_csp = "libcsp"
 LAYERSERIES_COMPAT_csp = "kirkstone"
 
-IMAGE_INSTALL:append = " csp-handler"
+IMAGE_INSTALL:append = " csp-handler cspd"

--- a/zero/meta-csp/conf/layer.conf
+++ b/zero/meta-csp/conf/layer.conf
@@ -3,7 +3,8 @@ BBPATH .= ":${LAYERDIR}"
 
 # We have recipes-* directories, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-cspd/csp-handler/csp-handler_*.bb \
-            ${LAYERDIR}/recipes-cspd/systemd/cspd_*.bb"
+            ${LAYERDIR}/recipes-cspd/systemd/cspd_*.bb \
+            ${LAYERDIR}/recipes-csp-server-client/csp-server-client_*.bb"
 
 BBFILE_COLLECTIONS += "csp"
 BBFILE_PATTERN_csp = "^${LAYERDIR}/"
@@ -12,4 +13,4 @@ BBFILE_PRIORITY_csp = "6"
 LAYERDEPENDS_csp = "libcsp"
 LAYERSERIES_COMPAT_csp = "kirkstone"
 
-IMAGE_INSTALL:append = " csp-handler cspd"
+IMAGE_INSTALL:append = " csp-handler cspd csp-server-client"

--- a/zero/meta-csp/recipes-csp-server-client/csp-server-client_0.bb
+++ b/zero/meta-csp/recipes-csp-server-client/csp-server-client_0.bb
@@ -1,0 +1,19 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2915dc85ab8fd26629e560d023ef175c"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+SRC_URI = "file://csp_server_client.c \
+           file://csp_server_client_posix.c \
+           file://Makefile \
+           file://LICENSE"
+
+S = "${WORKDIR}"
+
+DEPENDS:append = "libcsp"
+
+EXTRA_OEMAKE = "DESTDIR=${D} LIBDIR=${libdir} INCLUDEDIR=${includedir} BINDIR=${bindir}"
+
+do_install() {
+    oe_runmake install
+}

--- a/zero/meta-csp/recipes-csp-server-client/files/LICENSE
+++ b/zero/meta-csp/recipes-csp-server-client/files/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2009-2021 CSP Contributers (see AUTHORS file)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/zero/meta-csp/recipes-csp-server-client/files/Makefile
+++ b/zero/meta-csp/recipes-csp-server-client/files/Makefile
@@ -1,0 +1,9 @@
+all:
+	${CC} csp_server_client.c csp_server_client_posix.c -o csp_server_client -l csp -pthread
+
+install:
+	install -d ${DESTDIR}${BINDIR}
+	install -m 0755 csp_server_client ${DESTDIR}${BINDIR}
+
+clean:
+	rm -rf csp_server_client

--- a/zero/meta-csp/recipes-csp-server-client/files/csp_server_client.c
+++ b/zero/meta-csp/recipes-csp-server-client/files/csp_server_client.c
@@ -1,0 +1,313 @@
+#include <csp/csp_debug.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <csp/csp.h>
+#include <csp/drivers/usart.h>
+#include <csp/drivers/can_socketcan.h>
+#include <csp/interfaces/csp_if_zmqhub.h>
+
+
+/* These three functions must be provided in arch specific way */
+int router_start(void);
+int server_start(void);
+int client_start(void);
+
+/* Server port, the port the server listens on for incoming connections from the client. */
+#define MY_SERVER_PORT		10
+
+/* Commandline options */
+static uint8_t server_address = 255;
+
+/* test mode, used for verifying that host & client can exchange packets over the loopback interface */
+static bool test_mode = false;
+static unsigned int server_received = 0;
+
+/* Server task - handles requests from clients */
+void server(void) {
+
+	csp_print("Server task started\n");
+
+	/* Create socket with no specific socket options, e.g. accepts CRC32, HMAC, etc. if enabled during compilation */
+	csp_socket_t sock = {0};
+
+	/* Bind socket to all ports, e.g. all incoming connections will be handled here */
+	csp_bind(&sock, CSP_ANY);
+
+	/* Create a backlog of 10 connections, i.e. up to 10 new connections can be queued */
+	csp_listen(&sock, 10);
+
+	/* Wait for connections and then process packets on the connection */
+	while (1) {
+
+		/* Wait for a new connection, 10000 mS timeout */
+		csp_conn_t *conn;
+		if ((conn = csp_accept(&sock, 10000)) == NULL) {
+			/* timeout */
+			continue;
+		}
+
+		/* Read packets on connection, timout is 100 mS */
+		csp_packet_t *packet;
+		while ((packet = csp_read(conn, 50)) != NULL) {
+			switch (csp_conn_dport(conn)) {
+			case MY_SERVER_PORT:
+				/* Process packet here */
+				csp_print("Packet received on MY_SERVER_PORT: %s\n", (char *) packet->data);
+				csp_buffer_free(packet);
+				++server_received;
+				break;
+
+			default:
+				/* Call the default CSP service handler, handle pings, buffer use, etc. */
+				csp_service_handler(packet);
+				break;
+			}
+		}
+
+		/* Close current connection */
+		csp_close(conn);
+
+	}
+
+	return;
+
+}
+/* End of server task */
+
+/* Client task sending requests to server task */
+void client(void) {
+
+	csp_print("Client task started");
+
+	unsigned int count = 'A';
+
+	while (1) {
+
+		usleep(test_mode ? 200000 : 1000000);
+
+		/* Send ping to server, timeout 1000 mS, ping size 100 bytes */
+		int result = csp_ping(server_address, 1000, 100, CSP_O_NONE);
+		csp_print("Ping address: %u, result %d [mS]\n", server_address, result);
+        (void) result;
+
+		/* Send reboot request to server, the server has no actual implementation of csp_sys_reboot() and fails to reboot */
+		csp_reboot(server_address);
+		csp_print("reboot system request sent to address: %u\n", server_address);
+
+		/* Send data packet (string) to server */
+
+		/* 1. Connect to host on 'server_address', port MY_SERVER_PORT with regular UDP-like protocol and 1000 ms timeout */
+		csp_conn_t * conn = csp_connect(CSP_PRIO_NORM, server_address, MY_SERVER_PORT, 1000, CSP_O_NONE);
+		if (conn == NULL) {
+			/* Connect failed */
+			csp_print("Connection failed\n");
+			return;
+		}
+
+		/* 2. Get packet buffer for message/data */
+		csp_packet_t * packet = csp_buffer_get(100);
+		if (packet == NULL) {
+			/* Could not get buffer element */
+			csp_print("Failed to get CSP buffer\n");
+			return;
+		}
+
+		/* 3. Copy data to packet */
+        memcpy(packet->data, "Hello world ", 12);
+        memcpy(packet->data + 12, &count, 1);
+        memset(packet->data + 13, 0, 1);
+        count++;
+
+		/* 4. Set packet length */
+		packet->length = (strlen((char *) packet->data) + 1); /* include the 0 termination */
+
+		/* 5. Send packet */
+		csp_send(conn, packet);
+
+		/* 6. Close connection */
+		csp_close(conn);
+	}
+
+	return;
+}
+/* End of client task */
+
+static void print_usage(void)
+{
+	csp_print("Usage:\n"
+			  " -a <address>     local CSP address\n"
+			  " -r <address>     run client against server address\n"
+#if (CSP_HAVE_LIBSOCKETCAN)
+			  " -c <can-device>  add CAN device\n"
+#endif
+			  " -k <kiss-device> add KISS device (serial)\n"
+#if (CSP_HAVE_LIBZMQ)
+			  " -z <zmq-device>  add ZMQ device, e.g. \"localhost\"\n"
+#endif
+#if (CSP_USE_RTABLE)
+			  " -R <rtable>      set routing table\n"
+#endif
+			  " -t               enable test mode\n"
+			  " -h               print help\n");
+}
+
+/* main - initialization of CSP and start of server/client tasks */
+int main(int argc, char * argv[]) {
+
+    uint8_t address = 0;
+#if (CSP_HAVE_LIBSOCKETCAN)
+    const char * can_device = NULL;
+#endif
+    const char * kiss_device = NULL;
+#if (CSP_HAVE_LIBZMQ)
+    const char * zmq_device = NULL;
+#endif
+#if (CSP_USE_RTABLE)
+    const char * rtable = NULL;
+#endif
+    int opt;
+    while ((opt = getopt(argc, argv, "a:r:c:k:z:tR:h")) != -1) {
+        switch (opt) {
+            case 'a':
+                address = atoi(optarg);
+                break;
+            case 'r':
+                server_address = atoi(optarg);
+                break;
+#if (CSP_HAVE_LIBSOCKETCAN)
+            case 'c':
+                can_device = optarg;
+                break;
+#endif
+            case 'k':
+                kiss_device = optarg;
+                break;
+#if (CSP_HAVE_LIBZMQ)
+            case 'z':
+                zmq_device = optarg;
+                break;
+#endif
+            case 't':
+                test_mode = true;
+                break;
+#if (CSP_USE_RTABLE)
+            case 'R':
+                rtable = optarg;
+                break;
+#endif
+            case 'h':
+				print_usage();
+				exit(0);
+                break;
+            default:
+				print_usage();
+                exit(1);
+                break;
+        }
+    }
+
+    csp_print("Initialising CSP");
+
+    /* Init CSP */
+    csp_init();
+
+    /* Start router */
+    router_start();
+
+    /* Add interface(s) */
+    csp_iface_t * default_iface = NULL;
+    if (kiss_device) {
+        csp_usart_conf_t conf = {
+            .device = kiss_device,
+            .baudrate = 115200, /* supported on all platforms */
+            .databits = 8,
+            .stopbits = 1,
+            .paritysetting = 0,
+            .checkparity = 0};
+        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,  &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add KISS interface [%s], error: %d\n", kiss_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#if (CSP_HAVE_LIBSOCKETCAN)
+    if (can_device) {
+        int error = csp_can_socketcan_open_and_add_interface(can_device, CSP_IF_CAN_DEFAULT_NAME, address, 1000000, true, &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add CAN interface [%s], error: %d\n", can_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#endif
+#if (CSP_HAVE_LIBZMQ)
+    if (zmq_device) {
+        int error = csp_zmqhub_init(address, zmq_device, 0, &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add ZMQ interface [%s], error: %d\n", zmq_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#endif
+
+#if (CSP_USE_RTABLE)
+    if (rtable) {
+        int error = csp_rtable_load(rtable);
+        if (error < 1) {
+            csp_print("csp_rtable_load(%s) failed, error: %d\n", rtable, error);
+            exit(1);
+        }
+    } else if (default_iface) {
+        csp_rtable_set(0, 0, default_iface, CSP_NO_VIA_ADDRESS);
+    }
+#endif
+    if (!default_iface) {
+        /* no interfaces configured - run server and client in process, using loopback interface */
+        server_address = address;
+    }
+
+    csp_print("Connection table\r\n");
+    csp_conn_print_table();
+
+
+    csp_print("Interfaces\r\n");
+    csp_iflist_print();
+
+#if (CSP_USE_RTABLE)
+    csp_print("Route table\r\n");
+    csp_rtable_print();
+#endif
+
+    /* Start server thread */
+    if ((server_address == 255) ||  /* no server address specified, I must be server */
+        (default_iface == NULL)) {  /* no interfaces specified -> run server & client via loopback */
+        server_start();
+    }
+
+    /* Start client thread */
+    if ((server_address != 255) ||  /* server address specified, I must be client */
+        (default_iface == NULL)) {  /* no interfaces specified -> run server & client via loopback */
+        client_start();
+    }
+
+    /* Wait for execution to end (ctrl+c) */
+    while(1) {
+        sleep(3);
+
+        if (test_mode) {
+            /* Test mode is intended for checking that host & client can exchange packets over loopback */
+            if (server_received < 5) {
+                csp_print("Server received %u packets\n", server_received);
+                exit(1);
+            }
+            csp_print("Server received %u packets\n", server_received);
+            exit(0);
+        }
+    }
+
+    return 0;
+}

--- a/zero/meta-csp/recipes-csp-server-client/files/csp_server_client_posix.c
+++ b/zero/meta-csp/recipes-csp-server-client/files/csp_server_client_posix.c
@@ -1,0 +1,60 @@
+#include <csp/csp.h>
+#include <csp/csp_debug.h>
+#include <pthread.h>
+
+void server(void);
+void client(void);
+
+static int csp_pthread_create(void * (*routine)(void *)) {
+
+	pthread_attr_t attributes;
+	pthread_t handle;
+	int ret;
+
+	if (pthread_attr_init(&attributes) != 0) {
+		return CSP_ERR_NOMEM;
+	}
+	/* no need to join with thread to free its resources */
+	pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
+
+	ret = pthread_create(&handle, &attributes, routine, NULL);
+	pthread_attr_destroy(&attributes);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	return CSP_ERR_NONE;
+}
+
+static void * task_router(void * param) {
+
+	/* Here there be routing */
+	while (1) {
+		csp_route_work();
+	}
+
+	return NULL;
+}
+
+static void * task_server(void * param) {
+	server();
+	return NULL;
+}
+
+static void * task_client(void * param) {
+	client();
+	return NULL;
+}
+
+int router_start(void) {
+	return csp_pthread_create(task_router);
+}
+
+int server_start(void) {
+	return csp_pthread_create(task_server);
+}
+
+int client_start(void) {
+	return csp_pthread_create(task_client);
+}

--- a/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
+++ b/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
@@ -1,0 +1,21 @@
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+SRC_URI = "file://main.c \
+           file://handler.c \
+           file://router.c \
+           file://cspd.h \
+           file://Makefile \
+           file://LICENSE"
+
+S = "${WORKDIR}"
+
+DEPENDS:append = "libcsp"
+
+EXTRA_OEMAKE = "DESTDIR=${D} LIBDIR=${libdir} INCLUDEDIR=${includedir} BINDIR=${bindir} CFLAGS+='-D ZERO_CSP_ADDR=${ZERO_CSP_ADDRESS} -D PICO_CSP_ADDR=${PICO_CSP_ADDRESS}'"
+
+do_install() {
+    oe_runmake install
+}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/LICENSE
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
@@ -1,0 +1,17 @@
+SRCS=handler.c router.c main.c
+OBJS=$(SRCS:.c=.o)
+
+all: $(OBJS)
+	${CC} ${CFLAGS} -o csp_handler $(OBJS) -l csp
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJS): cspd.h
+
+install:
+	install -d ${DESTDIR}${BINDIR}
+	install -m 0755 csp_handler ${DESTDIR}${BINDIR}
+
+clean:
+	rm -rf csp_handler *.o

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
@@ -1,0 +1,24 @@
+#ifndef CSPD_H
+#define CSPD_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <csp/csp.h>
+
+#define PORT_A 10 /* for csp_server_client */
+
+#ifndef ZERO_CSP_ADDR
+#define ZERO_CSP_ADDR 1
+#endif
+
+#ifndef PICO_CSP_ADDR
+#define PICO_CSP_ADDR 2
+#endif
+
+/* handler.c */
+void *handle_csp_packet(void *param);
+
+/* router.c */
+int start_csp_router(void);
+
+#endif /* CSPD_H */

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
@@ -1,0 +1,43 @@
+#include "cspd.h"
+
+#include <csp/drivers/can_socketcan.h>
+
+void *handle_csp_packet(void *param)
+{
+	uint8_t address = ZERO_CSP_ADDR;
+
+	csp_iface_t *iface;
+	if ((iface = csp_can_socketcan_init("can0", address, 1000000, true)) == NULL) {
+		fprintf(stderr, "can't initialize socketcan\n");
+		exit(-1);
+	}
+	iface->is_default = 1;
+
+	/* csp_iflist_print(); */
+
+	csp_socket_t sock = {0};
+	csp_bind(&sock, CSP_ANY);
+	csp_listen(&sock, 10);
+
+	while (1) {
+		csp_conn_t *conn;
+		if ((conn = csp_accept(&sock, 10000)) == NULL) {
+			continue;
+		}
+
+		csp_packet_t *packet;
+		while ((packet = csp_read(conn, 50)) != NULL) {
+			switch (csp_conn_dport(conn)) {
+			case PORT_A:
+				csp_print("recived: %s\n", (char *)packet->data);
+				csp_buffer_free(packet);
+				break;
+
+			default:
+				csp_service_handler(packet);
+				break;
+			}
+		}
+		csp_close(conn);
+	}
+}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
@@ -1,0 +1,16 @@
+#include "cspd.h"
+
+/* uint8_t csp_dbg_packet_print = 1; */
+
+extern csp_conf_t csp_conf;
+
+int main()
+{
+	csp_conf.version = 1;
+	csp_init();
+
+	start_csp_router();
+	handle_csp_packet(NULL);
+
+	return 0;
+}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/router.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/router.c
@@ -1,0 +1,40 @@
+#include "cspd.h"
+
+#include <pthread.h>
+#include <errno.h>
+
+static void *router(void *param)
+{
+	while (1) {
+		csp_route_work();
+	}
+	return NULL;
+}
+
+int start_csp_router(void)
+{
+	pthread_attr_t attr;
+	pthread_t handle;
+
+	if (pthread_attr_init(&attr) != 0) {
+		perror("pthread_attr_init: ");
+		return -1;
+	}
+
+	if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0) {
+		perror("pthread_attr_setdetachstate: ");
+		return -1;
+	}
+
+	if (pthread_create(&handle, &attr, router, NULL) != 0) {
+		perror("pthread_create: ");
+		return -1;
+	}
+
+	if (pthread_attr_destroy(&attr) != 0) {
+		perror("pthread_attr_destroy: ");
+		return -1;
+	}
+
+	return 0;
+}

--- a/zero/meta-csp/recipes-cspd/systemd/cspd_0.bb
+++ b/zero/meta-csp/recipes-cspd/systemd/cspd_0.bb
@@ -1,0 +1,19 @@
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRC_URI = "file://cspd.service \
+           file://LICENSE"
+
+FILES:${PN} += "${systemd_unitdir}/system/cspd.service"
+S = "${WORKDIR}"
+
+DEPENDS:append = "csp-handler"
+
+inherit systemd
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "cspd.service"
+
+do_install:append() {
+  install -d ${D}/${systemd_unitdir}/system
+  install -m 0644 ${WORKDIR}/cspd.service ${D}/${systemd_unitdir}/system
+}

--- a/zero/meta-csp/recipes-cspd/systemd/files/LICENSE
+++ b/zero/meta-csp/recipes-cspd/systemd/files/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/zero/meta-csp/recipes-cspd/systemd/files/cspd.service
+++ b/zero/meta-csp/recipes-cspd/systemd/files/cspd.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=CSP Routing and execute Camera
+
+[Service]
+ExecStart=/usr/bin/csp_handler
+
+[Install]
+WantedBy=multi-user.target

--- a/zero/meta-scsat1-rpi/conf/distro/include/scsat1-rpi-variables.inc
+++ b/zero/meta-scsat1-rpi/conf/distro/include/scsat1-rpi-variables.inc
@@ -1,0 +1,3 @@
+# csp address
+ZERO_CSP_ADDRESS = "12"
+PICO_CSP_ADDRESS = "13"

--- a/zero/meta-scsat1-rpi/conf/distro/scsat1-rpi.conf
+++ b/zero/meta-scsat1-rpi/conf/distro/scsat1-rpi.conf
@@ -1,2 +1,8 @@
 DISTRO_NAME = "SC-Sat1 RPi Distro"
 DISTRO_VERSION = "0.1"
+
+DISTRO_FEATURES:append = " systemd"
+DISTRO_FEATURES:BACKFILL_CONSIDERED += "sysvinit"
+VIRTUAL-RUNTIME:init_manager = "systemd"  
+VIRTUAL-RUNTIME:initscripts = ""
+INIT_MANAGER = "systemd"

--- a/zero/meta-scsat1-rpi/conf/distro/scsat1-rpi.conf
+++ b/zero/meta-scsat1-rpi/conf/distro/scsat1-rpi.conf
@@ -6,3 +6,5 @@ DISTRO_FEATURES:BACKFILL_CONSIDERED += "sysvinit"
 VIRTUAL-RUNTIME:init_manager = "systemd"  
 VIRTUAL-RUNTIME:initscripts = ""
 INIT_MANAGER = "systemd"
+
+require conf/distro/include/scsat1-rpi-variables.inc


### PR DESCRIPTION
CSPパケットを処理するためのバイナリを追加

- csp_server_client
libcsp exampleのコードをそのまま移植
- csp_handler (systemd)
scsat1-rpiで動作するルーティング・命令のハンドリングを実装している
今回は自分自身へのパケットとcsp_server_clientのパケットを処理している