### PR TITLE
add a layer for debugging

### DIFF
--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-debug"
+BBFILE_PATTERN_meta-debug = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-debug = "6"
+
+LAYERDEPENDS_meta-debug = "core"
+LAYERSERIES_COMPAT_meta-debug = "kirkstone"

--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -17,4 +17,5 @@ EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
 IMAGE_INSTALL:append = " can-utils \
     linux-firmware-rpidistro-bcm43430 kernel-module-cfg80211 kernel-module-brcmfmac \
     wpa-supplicant \
+    openssh ssh-pregen-hostkeys openssh-sftp-server \
 "

--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -11,3 +11,5 @@ BBFILE_PRIORITY_meta-debug = "6"
 
 LAYERDEPENDS_meta-debug = "core"
 LAYERSERIES_COMPAT_meta-debug = "kirkstone"
+
+EXTRA_IMAGE_FEATURES:append = " debug-tweaks"

--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -13,3 +13,4 @@ LAYERDEPENDS_meta-debug = "core"
 LAYERSERIES_COMPAT_meta-debug = "kirkstone"
 
 EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
+IMAGE_INSTALL:append = " can-utils"

--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -13,4 +13,6 @@ LAYERDEPENDS_meta-debug = "core"
 LAYERSERIES_COMPAT_meta-debug = "kirkstone"
 
 EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
-IMAGE_INSTALL:append = " can-utils"
+IMAGE_INSTALL:append = " can-utils \
+    linux-firmware-rpidistro-bcm43430 kernel-module-cfg80211 kernel-module-brcmfmac \
+"

--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -3,6 +3,7 @@ BBPATH .= ":${LAYERDIR}"
 
 # We have recipes-* directories, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend \
+            ${LAYERDIR}/recipes-core/systemd/systemd-conf_%.bbappend \
             "
 
 BBFILE_COLLECTIONS += "meta-debug"

--- a/zero/meta-debug/conf/layer.conf
+++ b/zero/meta-debug/conf/layer.conf
@@ -2,8 +2,8 @@
 BBPATH .= ":${LAYERDIR}"
 
 # We have recipes-* directories, add to BBFILES
-BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
-            ${LAYERDIR}/recipes-*/*/*.bbappend"
+BBFILES += "${LAYERDIR}/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend \
+            "
 
 BBFILE_COLLECTIONS += "meta-debug"
 BBFILE_PATTERN_meta-debug = "^${LAYERDIR}/"
@@ -15,4 +15,5 @@ LAYERSERIES_COMPAT_meta-debug = "kirkstone"
 EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
 IMAGE_INSTALL:append = " can-utils \
     linux-firmware-rpidistro-bcm43430 kernel-module-cfg80211 kernel-module-brcmfmac \
+    wpa-supplicant \
 "

--- a/zero/meta-debug/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa_supplicant-wlan0.conf
+++ b/zero/meta-debug/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa_supplicant-wlan0.conf
@@ -1,0 +1,9 @@
+ctrl_interface=/var/run/wpa_supplicant
+ctrl_interface_group=0
+update_config=1
+country=JP
+
+network={
+	ssid="WiFi-SSID"
+	psk="WiFi-PASS"
+}

--- a/zero/meta-debug/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/zero/meta-debug/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,21 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://wpa_supplicant-wlan0.conf"
+
+inherit systemd
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "wpa_supplicant@wlan0.service"
+FILES:${PN} += "${systemd_unitdir}/system/"
+
+do_compile:append() {
+    sed -i -e "s/WiFi-SSID/${DEBUG_WIFI_SSID}/g" ${WORKDIR}/wpa_supplicant-wlan0.conf
+    sed -i -e "s/WiFi-PASS/${DEBUG_WIFI_PASS}/g" ${WORKDIR}/wpa_supplicant-wlan0.conf
+}
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/wpa_supplicant/
+    install -m 600 ${WORKDIR}/wpa_supplicant-wlan0.conf ${D}${sysconfdir}/wpa_supplicant/
+
+    install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+    ln -s -r ${D}${systemd_unitdir}/system/wpa_supplicant@.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/wpa_supplicant@wlan0.service
+}

--- a/zero/meta-debug/recipes-core/systemd/systemd-conf/wlan.network
+++ b/zero/meta-debug/recipes-core/systemd/systemd-conf/wlan.network
@@ -1,0 +1,14 @@
+[Match]
+Name=wlan*
+KernelCommandLine=!nfsroot
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=fallback
+MulticastDNS=yes
+
+[DHCPv4]
+UseMTU=yes
+RouteMetric=10
+ClientIdentifier=mac
+MaxAttempts=1

--- a/zero/meta-debug/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/zero/meta-debug/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://wlan.network"
+
+FILES:${PN} += "${sysconfdir}/systemd/network/wlan.network"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/systemd/network
+    install -m 0644 ${WORKDIR}/wlan.network ${D}${sysconfdir}/systemd/network
+}

--- a/zero/meta-debug/recipes-core/systemd/systemd/resolved.conf
+++ b/zero/meta-debug/recipes-core/systemd/systemd/resolved.conf
@@ -1,0 +1,3 @@
+[Resolve]
+MulticastDNS=yes
+LLMNR=yes

--- a/zero/meta-debug/recipes-core/systemd/systemd_%.bbappend
+++ b/zero/meta-debug/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://resolved.conf"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/systemd
+    install -m 0644 ${WORKDIR}/resolved.conf ${D}${sysconfdir}/systemd
+}

--- a/zero/meta-scsat1-rpi/conf/distro/include/scsat1-rpi-variables.inc
+++ b/zero/meta-scsat1-rpi/conf/distro/include/scsat1-rpi-variables.inc
@@ -1,3 +1,7 @@
 # csp address
 ZERO_CSP_ADDRESS = "12"
 PICO_CSP_ADDRESS = "13"
+
+# debug
+DEBUG_WIFI_SSID ??= ""
+DEBUG_WIFI_PASS ??= ""


### PR DESCRIPTION
デバッグ用のレイヤを追加

使用方法：`build/conf/bblayers.conf` に meta-debug へのパスを追加する

利用可能：
- root login
- canutils (cansend, candump, cangen etc.)
- wifi
- ssh