### PR TITLE
fix cmake variable

### DIFF
--- a/pico/CMakeLists.txt
+++ b/pico/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 set(BOARD rpi_pico)
 
-if (USE_UART1)
+if (CONSOLE STREQUAL uart1)
     list(APPEND EXTRA_DTC_OVERLAY_FILE "uart1.overlay")
 endif()
 

--- a/pico/CMakeLists.txt
+++ b/pico/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(BOARD, rpi_pico)
+set(BOARD rpi_pico)
 
 if (USE_UART1)
     list(APPEND EXTRA_DTC_OVERLAY_FILE "uart1.overlay")


### PR DESCRIPTION
## 構文エラーの修正
`set()` に不要なカンマがあったので修正

## コンソール指定方法の変更
サンプルプログラムに合わせてコンソール指定方法を柔軟にするために
```
$ west build -b rpi_pico scsat1-rpi/pico -- -DCONSOLE=uart1
```
と文字列を指定するように変更