### PR TITLE
github: workflow: build-pico: Add ubuntu-24.04

### DIFF
--- a/.github/workflows/build-pico.yaml
+++ b/.github/workflows/build-pico.yaml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   build-zephyr:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-latest
         board:
           - rpi_pico
         python-version:
@@ -19,6 +21,8 @@ jobs:
           - '3.11'
         sdk-version:
           - '0.16.4'
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Setup Python ${{ matrix.python-version }}


### PR DESCRIPTION
Add ubuntu-24.04 as a GitHub Actions runner.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>