### PR TITLE
pico: Add addr argument to csp_usart_open_and_add_kiss_interface

### DIFF
--- a/pico/sample/csp-send/src/main.c
+++ b/pico/sample/csp-send/src/main.c
@@ -35,12 +35,11 @@ int main(void)
 				 .stopbits = 1,
 				 .paritysetting = 0};
 	int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,
-							  &default_iface);
+							  CSP_SRC_ADDR, &default_iface);
 	if (error != CSP_ERR_NONE) {
 		LOG_ERR("failed to add KISS interface [%s], error: %d", kiss_device, error);
 		exit(1);
 	}
-	default_iface->addr = CSP_SRC_ADDR;
 	default_iface->is_default = 1;
 
 	LOG_DBG("successful add KISS interface [%s]", kiss_device);

--- a/pico/sample/csp-server/src/main.c
+++ b/pico/sample/csp-server/src/main.c
@@ -86,12 +86,11 @@ int main(void)
 				 .stopbits = 1,
 				 .paritysetting = 0};
 	int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,
-							  &default_iface);
+							  CSP_SRC_ADDR, &default_iface);
 	if (error != CSP_ERR_NONE) {
 		LOG_ERR("failed to add KISS interface [%s], error: %d\n", kiss_device, error);
 		exit(1);
 	}
-	default_iface->addr = CSP_SRC_ADDR;
 	default_iface->is_default = 1;
 
 	server_start();

--- a/pico/src/csp.c
+++ b/pico/src/csp.c
@@ -112,13 +112,12 @@ int csp_server_start(void)
 				 .stopbits = PICO_UART0_STOPBITS,
 				 .paritysetting = PICO_UART0_PARITY};
 	error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,
-						      &default_iface);
+						      PICO_CSP_ADDR, &default_iface);
 	if (error != CSP_ERR_NONE) {
 		LOG_ERR("failed to add KISS interface [%s], error: %d", kiss_device, error);
 		ret = -1;
 		goto end;
 	}
-	default_iface->addr = PICO_CSP_ADDR;
 	default_iface->is_default = 1;
 
 	server_start();

--- a/zero/meta-csp/recipes-csp-server-client/files/csp_server_client.c
+++ b/zero/meta-csp/recipes-csp-server-client/files/csp_server_client.c
@@ -232,13 +232,12 @@ int main(int argc, char *argv[])
 					 .stopbits = 1,
 					 .paritysetting = 0};
 		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,
-								  &default_iface);
+								  address, &default_iface);
 		if (error != CSP_ERR_NONE) {
 			csp_print("failed to add KISS interface [%s], error: %d\n", kiss_device,
 				  error);
 			exit(1);
 		}
-		default_iface->addr = address;
 		default_iface->is_default = 1;
 	}
 #if (CSP_HAVE_LIBSOCKETCAN)

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
@@ -37,13 +37,12 @@ int main()
 		.paritysetting = 0,
 	};
 	int error = csp_usart_open_and_add_kiss_interface(&usart_conf, CSP_IF_KISS_DEFAULT_NAME,
-							  &usart_iface);
+							  RPI_ZERO_UART_ADDR, &usart_iface);
 	if (error != CSP_ERR_NONE) {
 		csp_print("failed to add KISS interface [%s], error: %d\n", usart_conf.device,
 			  error);
 		exit(1);
 	}
-	usart_iface->addr = RPI_ZERO_UART_ADDR;
 	usart_iface->netmask = csp_id_get_host_bits();
 
 	csp_rtable_set(RPI_PICO_UART_ADDR, csp_id_get_host_bits(), usart_iface, CSP_NO_VIA_ADDRESS);


### PR DESCRIPTION
The new `addr` parameter for the CSP address was added in libcsp/libcsp@c8ca4bf2220a1. This commit implements that change.