### PR TITLE
zero: Replace csp_print with sd_journal_print

### DIFF
--- a/zero/meta-csp/recipes-cspd/csp-handler/files/camera.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/camera.c
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 #include <dirent.h>
+#include <systemd/sd-journal.h>
 #include "cspd.h"
 
 #define CAM_FRAME_PATH   "/storageA/photo"
@@ -69,7 +70,7 @@ static int get_frame_file_count(uint16_t *count)
 
 	dir = opendir(CAM_FRAME_PATH);
 	if (dir == NULL) {
-		csp_print("Failed to open dir %s\n", CAM_FRAME_PATH);
+		sd_journal_print(LOG_ERR, "Failed to open dir %s\n", CAM_FRAME_PATH);
 		ret = -1;
 		goto end;
 	}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
@@ -6,6 +6,7 @@
 
 #include "cspd.h"
 
+#include <systemd/sd-journal.h>
 #include <csp/drivers/can_socketcan.h>
 
 void *handle_csp_packet(void *param)
@@ -24,7 +25,7 @@ void *handle_csp_packet(void *param)
 		while ((packet = csp_read(conn, 50)) != NULL) {
 			switch (csp_conn_dport(conn)) {
 			case PORT_A:
-				csp_print("recived: %s\n", (char *)packet->data);
+				sd_journal_print(LOG_ERR, "recived: %s\n", (char *)packet->data);
 				csp_buffer_free(packet);
 				break;
 

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
@@ -6,6 +6,7 @@
 
 #include "cspd.h"
 
+#include <systemd/sd-journal.h>
 #include <csp/csp_rtable.h>
 #include <csp/drivers/can_socketcan.h>
 #include <csp/drivers/usart.h>
@@ -21,7 +22,7 @@ int main()
 	/* CAN interface */
 	csp_iface_t *can_iface = csp_can_socketcan_init("can0", RPI_ZERO_CAN_ADDR, 1000000, true);
 	if (can_iface == NULL) {
-		csp_print("failed to add CAN interface [can0]");
+		sd_journal_print(LOG_ERR, "failed to add CAN interface [can0]");
 		exit(1);
 	}
 	can_iface->is_default = 1;
@@ -39,7 +40,7 @@ int main()
 	int error = csp_usart_open_and_add_kiss_interface(&usart_conf, CSP_IF_KISS_DEFAULT_NAME,
 							  RPI_ZERO_UART_ADDR, &usart_iface);
 	if (error != CSP_ERR_NONE) {
-		csp_print("failed to add KISS interface [%s], error: %d\n", usart_conf.device,
+		sd_journal_print(LOG_ERR, "failed to add KISS interface [%s], error: %d\n", usart_conf.device,
 			  error);
 		exit(1);
 	}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/temp.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/temp.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <time.h>
 #include <sys/ioctl.h>
+#include <systemd/sd-journal.h>
 #include <linux/i2c-dev.h>
 #include "cspd.h"
 
@@ -24,22 +25,22 @@ static int get_tmp175_temp(uint16_t *temp)
 
 	sprintf(i2c_dev_fn, "/dev/i2c-%d", I2C_DEV_NO);
 	if ((fd = open(i2c_dev_fn, O_RDWR)) < 0) {
-		csp_print("Faild to open i2c port\n");
+		sd_journal_print(LOG_ERR, "Faild to open i2c port\n");
 		return -1;
 	}
 
 	if (ioctl(fd, I2C_SLAVE, I2C_TMP175_SLAVE_ADDR) < 0) {
-		csp_print("Unable to get bus access to talk to slave\n");
+		sd_journal_print(LOG_ERR, "Unable to get bus access to talk to slave\n");
 		return -1;
 	}
 
 	if ((write(fd, &reg, 1)) != 1) {
-		csp_print("Error writing to i2c slave\n");
+		sd_journal_print(LOG_ERR, "Error writing to i2c slave\n");
 		return -1;
 	}
 
 	if (read(fd, dat, 2) != 2) {
-		csp_print("Error reading from i2c slave\n");
+		sd_journal_print(LOG_ERR, "Error reading from i2c slave\n");
 		return -1;
 	}
 


### PR DESCRIPTION
cspd will be run by systemd. We can depend on sd_journal_print, which has better integration with systemd's logging system.

ref) https://0pointer.de/blog/projects/journal-submit.html