### PR TITLE
zero: meta-arudcam: Change rev to AUTOREV

### DIFF
--- a/zero/meta-arducam/recipes-multimedia/libcamera-arducam/libcamera-arducam_0.0.5.bb
+++ b/zero/meta-arducam/recipes-multimedia/libcamera-arducam/libcamera-arducam_0.0.5.bb
@@ -12,7 +12,7 @@ SRC_URI = " \
         git://github.com/ArduCAM/libcamera.git;protocol=https;branch=arducam \
 "
 
-SRCREV = "e0a93d12f56ff9cd79520c2c99f2ef3b22c2f0a1"
+SRCREV = "${AUTOREV}"
 
 PE = "1"
 


### PR DESCRIPTION
As of September 2024, the following build error occurred.

  ERROR: libcamera-arducam-1_0.0.5-r0 do_fetch: Fetcher failure:
  Unable to find revision e0a93d12f56ff9cd79520c2c99f2ef3b22c2f0a1
  in branch arducam even from upstream

Upon checking the Arducam libcamera repository, a new tag (arducam_v0.3.1+20240830) was created on August 30, 2024, which resulted in the hash value of the previously specified commit being changed. Therefore, we will switch to using AUTOREV to specify the latest revision from a specific revision.