### PR TITLE
Fix version for libcamera to 0.3.0

### DIFF
--- a/zero/meta-arducam/recipes-multimedia/libcamera-arducam/libcamera-arducam_0.0.5.bb
+++ b/zero/meta-arducam/recipes-multimedia/libcamera-arducam/libcamera-arducam_0.0.5.bb
@@ -12,7 +12,7 @@ SRC_URI = " \
         git://github.com/ArduCAM/libcamera.git;protocol=https;branch=arducam \
 "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "e0a93d12f56ff9cd79520c2c99f2ef3b22c2f0a1"
 
 PE = "1"
 

--- a/zero/meta-arducam/recipes-multimedia/libcamera-arducam/libcamera-arducam_0.3.0.bb
+++ b/zero/meta-arducam/recipes-multimedia/libcamera-arducam/libcamera-arducam_0.3.0.bb
@@ -9,14 +9,14 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = " \
-        git://github.com/ArduCAM/libcamera.git;protocol=https;branch=arducam \
+        https://github.com/ArduCAM/libcamera/archive/refs/tags/arducam_v0.3.0+20240618.tar.gz \
 "
 
-SRCREV = "e0a93d12f56ff9cd79520c2c99f2ef3b22c2f0a1"
+SRC_URI[sha256sum] = "ccd203f20e954e671f00ab8757880134689595481ca7b9f848b2fa5588572a28"
 
 PE = "1"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}/libcamera-arducam_v0.3.0-20240618"
 
 DEPENDS = "python3-pyyaml-native python3-jinja2-native python3-ply-native python3-jinja2-native udev gnutls chrpath-native libevent libyaml arducam-pivariety"
 DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'qt', 'qtbase qtbase-native', '', d)}"


### PR DESCRIPTION
In commit 27070e7, we changed to AUTOREV for libcamera arducam
branch, but the latest version now requires meson 0.63 or higher, and
since the version of kirkstone is 0.61, a build error occurs.
Therefore, we will change to use the 0.3.0 tag, which has been
verified to work. However, since the 0.3.0 tag does not exist on any
branch, the following warning will appear, but we will modify it to
use the release package(tar.gz).
    
    WARNING: libcamera-arducam-1_0.0.5-r0 do_unpack: QA Issue:
    libcamera-arducam: SRC_URI uses unstable GitHub/GitLab archives,
    convert recipe to use git protocol [src-uri-bad]
