### PR TITLE
github: workflow: build-pico: Remove Python 3.9 support

### DIFF
--- a/.github/workflows/build-pico.yaml
+++ b/.github/workflows/build-pico.yaml
@@ -16,7 +16,6 @@ jobs:
         board:
           - rpi_pico
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
         sdk-version:


### PR DESCRIPTION
Zephyr 3.7 LTS requires Python 3.10 or higher. Therefore, building with Python 3.9 is no longer supported. This commit removes Python 3.9 from the build targets to reflect this requirement.

Note: Ubuntu 20.04 ships with Python 3.8, which also doesn't meet Zephyr's minimum Python version requirement. Users on Ubuntu 20.04 will need to install Python 3.10 or newer manually to build Zephyr 3.7 LTS.