### PR TITLE
github: workflow: build-pico: Replace ubuntu-latest

### DIFF
--- a/.github/workflows/build-pico.yaml
+++ b/.github/workflows/build-pico.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - ubuntu-latest
+          - ubuntu-22.04
         board:
           - rpi_pico
         python-version:


### PR DESCRIPTION
[ubuntu-latest will be updated](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/) from ubuntu-22.04 to ubuntu-24.04.  Replace ubuntu-latest with explicit one.