### PR TITLE
.gitlint: Add ignore line

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,5 @@
+[general]
+regex-style-search=true
+
+[ignore-body-lines]
+regex=^(?:(?:Signed-off|Acked|Co-Authored|Reported|Tested)-by: |\[\d+\]: https:\/\/)


### PR DESCRIPTION
Ignore any lines starting with a) "Signed-off" or similar, b) Link reference syntax which start with "[id]: ".

The first one is for signed-off line. If we don't ignore it, gitlink accepts body with only a signed-off line, which is not what we want.

The second part is for any line with a reference URL. A URL can be longer than max line length but we don't want gitlint to warn about it.