### PR TITLE
zero: meta-csp: add image capture capability for scsat1

### DIFF
--- a/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
+++ b/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
@@ -8,13 +8,14 @@ SRC_URI = "file://main.c \
            file://router.c \
            file://temp.c \
            file://camera.c \
+           file://yuyv_to_rgb.h \
            file://cspd.h \
            file://Makefile \
            file://LICENSE"
 
 S = "${WORKDIR}"
 
-DEPENDS:append = "libcsp"
+DEPENDS:append = "libcsp jpeg"
 
 EXTRA_OEMAKE = "DESTDIR=${D} LIBDIR=${libdir} INCLUDEDIR=${includedir} BINDIR=${bindir} \
                 CFLAGS+='-D MAIN_OBC_CAN_ADDR=${MAIN_OBC_CAN_ADDRESS} -D RPI_ZERO_CAN_ADDR=${RPI_ZERO_CAN_ADDRESS} -D RPI_ZERO_UART_ADDR=${RPI_ZERO_UART_ADDRESS} -D RPI_PICO_UART_ADDR=${RPI_PICO_UART_ADDRESS}'"

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
@@ -2,7 +2,7 @@ SRCS=camera.c temp.c handler.c router.c main.c
 OBJS=$(SRCS:.c=.o)
 
 all: $(OBJS)
-	${CC} ${CFLAGS} -o csp_handler $(OBJS) -l csp
+	${CC} ${CFLAGS} -o csp_handler $(OBJS) -l csp -ljpeg
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/camera.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/camera.c
@@ -6,10 +6,241 @@
 
 #include <sys/types.h>
 #include <dirent.h>
+#include <linux/videodev2.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <jpeglib.h>
+#include <unistd.h>
+
 #include "cspd.h"
+#include "yuyv_to_rgb.h"
+
+#define CAMERA_WIDTH  1920
+#define CAMERA_HEIGHT 1080
+#define MMAP_COUNT    2
 
 #define CAM_FRAME_PATH   "/storageA/photo"
 #define CAM_FRAME_PREFIX "frame"
+
+static int xioctl(int fd, int request, void *arg)
+{
+	for (;;) {
+		int ret = ioctl(fd, request, arg);
+		if (ret < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			return -errno;
+		}
+		break;
+	}
+
+	return 0;
+}
+
+static void get_next_filename(char *filename, size_t size)
+{
+	unsigned num = 0;
+	while (1) {
+		snprintf(filename, size, "%s/frame-%03d.jpg", CAM_FRAME_PATH, num);
+		if (access(filename, F_OK) != 0) {
+			return;
+		}
+		num++;
+	}
+}
+
+static void jpeg_write_file(uint8_t *prgb, int width, int height)
+{
+	struct jpeg_compress_struct cinfo;
+	struct jpeg_error_mgr jerr;
+
+	cinfo.err = jpeg_std_error(&jerr);
+	jpeg_create_compress(&cinfo);
+
+	char filename[256];
+	get_next_filename(filename, sizeof(filename));
+
+	FILE *fp = fopen(filename, "wb");
+	if (!fp) {
+		perror("fopen");
+		return;
+	}
+
+	jpeg_stdio_dest(&cinfo, fp);
+
+	cinfo.image_width = width;
+	cinfo.image_height = height;
+	cinfo.input_components = 3; // RGB
+	cinfo.in_color_space = JCS_RGB;
+
+	jpeg_set_defaults(&cinfo);
+	jpeg_start_compress(&cinfo, TRUE);
+
+	for (int y = 0; y < height; y++) {
+		JSAMPROW row_pointer[1];               // Pointer to a single row
+		row_pointer[0] = &prgb[y * width * 3]; // RGB data
+		jpeg_write_scanlines(&cinfo, row_pointer, 1);
+	}
+
+	jpeg_finish_compress(&cinfo);
+	fclose(fp);
+
+	jpeg_destroy_compress(&cinfo);
+}
+
+// Function to capture images
+static int capture_jpeg_frame(const char *camera_dev)
+{
+	int fd, width, height, length, ret;
+	struct v4l2_format fmt;
+	struct v4l2_requestbuffers req;
+	struct v4l2_buffer buf;
+	enum v4l2_buf_type type;
+	void *mmap_p[MMAP_COUNT];
+	__u32 mmap_l[MMAP_COUNT];
+	uint8_t *yuyvbuf, *rgbbuf;
+
+	fd = open(camera_dev, O_RDWR, 0);
+	if (fd < 0) {
+		perror("open");
+		return -1;
+	}
+
+	memset(&fmt, 0, sizeof(fmt));
+	fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	fmt.fmt.pix.width = CAMERA_WIDTH;
+	fmt.fmt.pix.height = CAMERA_HEIGHT;
+	fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
+	fmt.fmt.pix.field = V4L2_FIELD_INTERLACED;
+	ret = xioctl(fd, VIDIOC_S_FMT, &fmt);
+	if (ret < 0 || fmt.fmt.pix.pixelformat != V4L2_PIX_FMT_YUYV || fmt.fmt.pix.width <= 0 ||
+	    fmt.fmt.pix.height <= 0) {
+		perror("ioctl(VIDIOC_S_FMT)");
+		return -1;
+	}
+	width = fmt.fmt.pix.width;
+	height = fmt.fmt.pix.height;
+	length = width * height;
+
+	yuyvbuf = malloc(2 * length);
+	if (!yuyvbuf) {
+		perror("malloc");
+		return -1;
+	}
+
+	memset(&req, 0, sizeof(req));
+	req.count = MMAP_COUNT;
+	req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	req.memory = V4L2_MEMORY_MMAP;
+	ret = xioctl(fd, VIDIOC_REQBUFS, &req);
+	if (ret < 0) {
+		perror("ioctl(VIDIOC_REQBUFS)");
+		return -1;
+	}
+
+	for (unsigned i = 0; i < req.count; i++) {
+		memset(&buf, 0, sizeof(buf));
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+		ret = xioctl(fd, VIDIOC_QUERYBUF, &buf);
+		if (ret < 0) {
+			perror("ioctl(VIDIOC_QUERYBUF)");
+			return -1;
+		}
+
+		mmap_p[i] = mmap(NULL, buf.length, PROT_READ, MAP_SHARED, fd, buf.m.offset);
+		if (mmap_p[i] == MAP_FAILED) {
+			perror("mmap");
+			return -1;
+		}
+		mmap_l[i] = buf.length;
+	}
+
+	for (unsigned i = 0; i < req.count; i++) {
+		memset(&buf, 0, sizeof(buf));
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+		ret = xioctl(fd, VIDIOC_QBUF, &buf);
+		if (ret < 0) {
+			perror("ioctl(VIDIOC_QBUF)");
+			return -1;
+		}
+	}
+
+	type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	ret = xioctl(fd, VIDIOC_STREAMON, &type);
+	if (ret < 0) {
+		perror("ioctl(VIDIOC_STREAMON)");
+		return -1;
+	}
+
+	fd_set fds;
+	FD_ZERO(&fds);
+	FD_SET(fd, &fds);
+	while (1) {
+		ret = select(fd + 1, &fds, NULL, NULL, NULL);
+		if (ret < 0 && errno != EINTR) {
+			perror("select");
+			return -1;
+		}
+		if (FD_ISSET(fd, &fds)) {
+			memset(&buf, 0, sizeof(buf));
+			buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+			buf.memory = V4L2_MEMORY_MMAP;
+			ret = xioctl(fd, VIDIOC_DQBUF, &buf);
+			if (ret < 0 || buf.bytesused < (__u32)(2 * length)) {
+				perror("ioctl(VIDIOC_DQBUF)");
+				return -1;
+			}
+			memcpy(yuyvbuf, mmap_p[buf.index], 2 * length);
+			ret = xioctl(fd, VIDIOC_QBUF, &buf);
+			if (ret < 0) {
+				perror("ioctl(VIDIOC_QBUF)");
+				return -1;
+			}
+			break;
+		}
+	}
+
+	xioctl(fd, VIDIOC_STREAMOFF, &type);
+	for (unsigned i = 0; i < req.count; i++) {
+		munmap(mmap_p[i], mmap_l[i]);
+	}
+	close(fd);
+
+	rgbbuf = malloc(3 * length);
+	if (!rgbbuf) {
+		perror("malloc");
+		return -1;
+	}
+
+	yuyv_to_rgb(yuyvbuf, rgbbuf, length);
+
+	jpeg_write_file(rgbbuf, width, height);
+
+	free(yuyvbuf);
+	free(rgbbuf);
+	return 0;
+}
+
+int camera_jpeg(const char *camera_dev)
+{
+	if (capture_jpeg_frame(camera_dev) < 0) {
+		csp_print("Image capture failed!\n");
+		return 1;
+	}
+	return 0;
+}
 
 static int init_photo_dir(void)
 {
@@ -98,6 +329,11 @@ void init_photo_dir_service(csp_conn_t *conn)
 void capture_frame_service(csp_conn_t *conn)
 {
 	(void)capture_frame();
+}
+
+void capture_jpeg_service(csp_conn_t *conn)
+{
+	(void)camera_jpeg("/dev/video0");
 }
 
 void get_frame_count_service(csp_conn_t *conn)

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/camera.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/camera.c
@@ -24,6 +24,7 @@
 
 #define CAMERA_WIDTH  1920
 #define CAMERA_HEIGHT 1080
+#define JPEG_QUALITY 90
 #define MMAP_COUNT    2
 
 #define CAM_FRAME_PATH   "/storageA/photo"
@@ -82,6 +83,7 @@ static void jpeg_write_file(uint8_t *prgb, int width, int height)
 	cinfo.in_color_space = JCS_RGB;
 
 	jpeg_set_defaults(&cinfo);
+	jpeg_set_quality(&cinfo, JPEG_QUALITY, TRUE);
 	jpeg_start_compress(&cinfo, TRUE);
 
 	for (int y = 0; y < height; y++) {

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
@@ -14,6 +14,7 @@
 #define PORT_T (11U) /* for get temperature */
 #define PORT_I (12U) /* for init photo dir */
 #define PORT_C (13U) /* for capture frame */
+#define PORT_J (15U) /* for capture JPEG*/
 #define PORT_F (14U) /* for get frame count */
 
 #ifndef MAIN_OBC_CAN_ADDR
@@ -44,4 +45,5 @@ void get_temp_service(csp_conn_t *conn);
 /* camera.c */
 void init_photo_dir_service(csp_conn_t *conn);
 void capture_frame_service(csp_conn_t *conn);
+void capture_jpeg_service(csp_conn_t *conn);
 void get_frame_count_service(csp_conn_t *conn);

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
@@ -43,6 +43,10 @@ void *handle_csp_packet(void *param)
 				csp_buffer_free(packet);
 				break;
 
+			case PORT_J:
+				capture_jpeg_service(conn);
+				csp_buffer_free(packet);
+				break;
 			case PORT_F:
 				get_frame_count_service(conn);
 				csp_buffer_free(packet);

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/yuyv_to_rgb.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/yuyv_to_rgb.h
@@ -1,0 +1,98 @@
+#ifndef YUYV_TO_RGB_H
+#define YUYV_TO_RGB_H
+
+#ifdef __ARM_NEON__
+/*
+ * Based on libyuv/source/row_neon.cc [https://code.google.com/p/libyuv]
+ */
+
+#define READYUYV                                                                                   \
+	"vld2.u8    {d0, d2}, [%0]!                \n"                                             \
+	"vmov.u8    d3, d2                         \n"                                             \
+	"vuzp.u8    d2, d3                         \n"                                             \
+	"vtrn.u32   d2, d3                         \n"
+
+#define YUV422TORGB                                                                                \
+	"veor.u8    d2, d26                        \n" /*subtract 128 from u and v*/               \
+	"vmull.s8   q8, d2, d24                    \n" /*  u/v B/R component      */               \
+	"vmull.s8   q9, d2, d25                    \n" /*  u/v G component        */               \
+	"vmov.u8    d1, #0                         \n" /*  split odd/even y apart */               \
+	"vtrn.u8    d0, d1                         \n"                                             \
+	"vsub.s16   q0, q0, q15                    \n" /*  offset y               */               \
+	"vmul.s16   q0, q0, q14                    \n"                                             \
+	"vadd.s16   d18, d19                       \n"                                             \
+	"vqadd.s16  d22, d0, d16                   \n" /* B */                                     \
+	"vqadd.s16  d23, d1, d16                   \n"                                             \
+	"vqadd.s16  d20, d0, d17                   \n" /* R */                                     \
+	"vqadd.s16  d21, d1, d17                   \n"                                             \
+	"vqadd.s16  d16, d0, d18                   \n" /* G */                                     \
+	"vqadd.s16  d17, d1, d18                   \n"                                             \
+	"vqshrun.s16 d0, q11, #6                   \n" /* B */                                     \
+	"vqshrun.s16 d1, q10, #6                   \n" /* R */                                     \
+	"vqshrun.s16 d2, q8, #6                    \n" /* G */                                     \
+	"vmovl.u8   q11, d0                        \n" /*  set up for reinterleave*/               \
+	"vmovl.u8   q10, d1                        \n"                                             \
+	"vmovl.u8   q8, d2                         \n"                                             \
+	"vtrn.u8    d22, d23                       \n"                                             \
+	"vtrn.u8    d20, d21                       \n"                                             \
+	"vtrn.u8    d16, d17                       \n"                                             \
+	"vmov.u8    d21, d16                       \n"
+
+static const int8_t __attribute__((vector_size(16))) kUVToRB = {
+	127, 127, 127, 127, 102, 102, 102, 102, 0, 0, 0, 0, 0, 0, 0, 0};
+static const int8_t __attribute__((vector_size(16))) kUVToG = {
+	-25, -25, -25, -25, -52, -52, -52, -52, 0, 0, 0, 0, 0, 0, 0, 0};
+
+static inline void yuyv_to_rgb(const uint8_t *src, uint8_t *dest, int length)
+{
+	asm volatile("vld1.u8    {d24}, [%3]                    \n"
+		     "vld1.u8    {d25}, [%4]                    \n"
+		     "vmov.u8    d26, #128                      \n"
+		     "vmov.u16   q14, #74                       \n"
+		     "vmov.u16   q15, #16                       \n"
+		     ".p2align  2                               \n"
+		     "1:                                          \n" READYUYV YUV422TORGB
+		     "subs       %2, %2, #8                     \n"
+		     "vst3.8     {d20, d21, d22}, [%1]!         \n"
+		     "bgt        1b                             \n"
+		     : "+r"(src),     /* %0 */
+		       "+r"(dest),    /* %1 */
+		       "+r"(length)   /* %2 */
+		     : "r"(&kUVToRB), /* %3 */
+		       "r"(&kUVToG)   /* %4 */
+		     : "cc", "memory", "q0", "q1", "q2", "q3", "q8", "q9", "q10", "q11", "q12",
+		       "q13", "q14", "q15");
+}
+
+#else /* __ARM_NEON__ */
+/*
+ * Based on libv4lconvert/rgbyuv.c [http://freecode.com/projects/libv4l]
+ */
+
+#define CLIP(color) (unsigned char)(((color) > 0xFF) ? 0xff : (((color) < 0) ? 0 : (color)))
+
+static inline void yuyv_to_rgb(const uint8_t *src, uint8_t *dest, int length)
+{
+	int j;
+
+	for (j = 0; j < length; j += 2) {
+		int u = src[1];
+		int v = src[3];
+		int u1 = (((u - 128) << 7) + (u - 128)) >> 6;
+		int rg = (((u - 128) << 1) + (u - 128) + ((v - 128) << 2) + ((v - 128) << 1)) >> 3;
+		int v1 = (((v - 128) << 1) + (v - 128)) >> 1;
+
+		*dest++ = CLIP(src[0] + v1);
+		*dest++ = CLIP(src[0] - rg);
+		*dest++ = CLIP(src[0] + u1);
+
+		*dest++ = CLIP(src[2] + v1);
+		*dest++ = CLIP(src[2] - rg);
+		*dest++ = CLIP(src[2] + u1);
+		src += 4;
+	}
+}
+
+#endif /* __ARM_NEON__ */
+
+#endif /* YUYV_TO_RGB_H */

--- a/zero/meta-csp/recipes-cspd/systemd/files/cspd.service
+++ b/zero/meta-csp/recipes-cspd/systemd/files/cspd.service
@@ -2,7 +2,7 @@
 Description=CSP Routing and execute Camera
 
 [Service]
-ExecStart=/usr/bin/csp_handler
+ExecStart=/usr/bin/libcamerify /usr/bin/csp_handler
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Implemented functionality to capture images (photos) using the camera on scsat1.
Modified the camera service to use `libcamerify` in front of the program to
ensure compatibility with libcamera.
Utilized `v4l2` for direct image capture from the camera.
This adds the capability to capture images from the camera on scsat1.

Change JPEG quality from default value 75 to 90.
Currently set as a define value, not a user configuration.