### PR TITLE
doc/zero: add warnings about the build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /zero/poky/
 /zero/meta-raspberrypi/
 /zero/meta-openembedded/
+/zero/meta-rauc/
+/zero/meta-rauc-community/

--- a/doc/zero/build.md
+++ b/doc/zero/build.md
@@ -7,6 +7,11 @@
 
 Install packages for your environment
 
+> [!CAUTION]
+> Requires `gcc-13` or lower
+> 
+> ref. #55
+
 ## Ubuntu
 
 ```shell


### PR DESCRIPTION
Add note to use `gcc-13` or lower as shown in #55

minor fix:
- add `meta-racu`, `meta-rauc-community` to gitignore