### PR TITLE
Add shell command for zero

### DIFF
--- a/zero/meta-csp/conf/layer.conf
+++ b/zero/meta-csp/conf/layer.conf
@@ -14,7 +14,7 @@ BBFILE_PRIORITY_csp = "6"
 LAYERDEPENDS_csp = "libcsp"
 LAYERSERIES_COMPAT_csp = "kirkstone"
 
-IMAGE_INSTALL:append = " csp-handler cspd csp-server-client"
+IMAGE_INSTALL:append = " csp-handler cspd csp-server-client glibc-utils"
 
 ENABLE_UART = "1"
 ENABLE_I2C = "1"

--- a/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
+++ b/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
@@ -19,6 +19,8 @@ SRC_URI = "file://main.c \
            file://file.h \
            file://upload.c \
            file://upload.h \
+           file://shell.c \
+           file://shell.h \
            file://cspd.h \
            file://Makefile \
            file://LICENSE"

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
@@ -1,4 +1,4 @@
-SRCS := upload.c file.c hwtest.c camera.c temp.c handler.c router.c main.c
+SRCS := shell.c upload.c file.c hwtest.c camera.c temp.c handler.c router.c main.c
 OBJS := $(SRCS:.c=.o)
 SYSTEMD_CFLAGS := $(shell pkg-config --cflags libsystemd)
 SYSTEMD_LIBS := $(shell pkg-config --libs libsystemd)

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <csp/csp.h>
 
+#define PORT_SHELL  (10U) /* for shell command */
 #define PORT_HWTEST (11U) /* for HWTEST program */
 #define PORT_FILE   (13U) /* for file related command */
 

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
@@ -12,6 +12,7 @@
 #include "utils.h"
 #include "hwtest.h"
 #include "file.h"
+#include "shell.h"
 
 void *handle_csp_packet(void *param)
 {
@@ -29,6 +30,9 @@ void *handle_csp_packet(void *param)
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
 			switch (csp_conn_dport(conn)) {
+			case PORT_SHELL:
+				shell_handler(packet);
+				break;
 			case PORT_HWTEST:
 				hwtest_handler(packet);
 				break;

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/main.c
@@ -13,6 +13,7 @@
 #include "handler.h"
 #include "router.h"
 #include "file.h"
+#include "shell.h"
 
 extern csp_conf_t csp_conf;
 
@@ -52,6 +53,7 @@ int main()
 	csp_rtable_set(MAIN_OBC_CAN_ADDR, csp_id_get_host_bits(), can_iface, CSP_NO_VIA_ADDRESS);
 
 	file_handler_init();
+	shell_handler_init();
 	start_csp_router();
 	handle_csp_packet(NULL);
 

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/shell.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/shell.c
@@ -1,0 +1,220 @@
+/* * Copyright (c) 2024 Space Cubics, LLC.  *
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#include "shell.h"
+
+#include <glib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <systemd/sd-journal.h>
+#include <sys/stat.h>
+#include <csp/csp_buffer.h>
+#include "cspd.h"
+#include "utils.h"
+#include "upload.h"
+
+#define SHELL_WORK_THREAD_SLEEP_SEC  (1U)
+#define SHELL_CMD_REPLY_INTERVAL_SEC (0.2)
+#define SHELL_CMD_STR_MAX_SIZE       (200U)
+#define SHELL_CMD_REPLY_TLM_MAX_CNT  (50U)
+
+/* Command size */
+#define SHELL_CMD_MIN_SIZE      (1U)
+#define SHELL_EXEC_CMD_MIN_SIZE (3U) + SHELL_CMD_STR_MAX_SIZE
+
+/* Command ID */
+#define SHELL_CMD (0U)
+
+/* Command argument offset */
+#define SHELL_CMD_TIMEOUT_OFFSET (1U)
+#define SHELL_CMD_STR_OFFSET     (3U)
+
+static GQueue shell_work_queue;
+static pthread_t shell_work;
+
+void send_cmd_reply(csp_packet_t *packet, uint8_t command_id, int err_code, uint8_t *result)
+{
+	struct shell_cmd_reply_telemetry tlm;
+	csp_packet_t *clone;
+
+	/*
+	 * This reply telemetry might be divided and sent in multiple parts. Since using
+	 * `send_cmd_reply()` would release the packet, so clone it before sending.
+	 */
+	clone = csp_buffer_clone(packet);
+
+	tlm.telemetry_id = command_id;
+	tlm.error_code = err_code;
+	if (result == NULL) {
+		memset(tlm.result, 0, SHELL_RESULT_BUF_SIZE);
+	} else {
+		memcpy(tlm.result, result, SHELL_RESULT_BUF_SIZE);
+	}
+
+	memcpy(clone->data, &tlm, sizeof(tlm));
+	clone->length = sizeof(tlm);
+
+	csp_sendto_reply(clone, clone, CSP_O_SAME);
+}
+
+static void shell_cmd(uint8_t command_id, csp_packet_t *packet)
+{
+	int ret;
+	FILE *fp;
+	char cmd[SHELL_CMD_STR_MAX_SIZE];
+	char result[SHELL_RESULT_BUF_SIZE] = {0};
+	uint16_t timeout_sec;
+	struct timeval timeout;
+	fd_set readfds;
+	int fd;
+	int nfds;
+	size_t rsize;
+	uint8_t reply_count = 0;
+
+	if (packet->length != SHELL_EXEC_CMD_MIN_SIZE) {
+		sd_journal_print(LOG_ERR, "Invalide command size: %d", packet->length);
+		ret = -EINVAL;
+		goto end;
+	}
+
+	strcpy(cmd, (const char *)&packet->data[SHELL_CMD_STR_OFFSET]);
+	timeout_sec = le16toh(*(unsigned short *)&packet->data[SHELL_CMD_TIMEOUT_OFFSET]);
+
+	sd_journal_print(LOG_INFO, "Shell command: %s (timeout: %d sec)", cmd, timeout_sec);
+
+	fp = popen(cmd, "r");
+	if (fp == NULL) {
+		sd_journal_print(LOG_ERR, "Unable to popen for shell command");
+		ret = -EIO;
+		goto end;
+	}
+
+	fd = fileno(fp);
+	FD_ZERO(&readfds);
+	FD_SET(fd, &readfds);
+	nfds = fd + 1;
+
+	timeout.tv_sec = timeout_sec;
+	timeout.tv_usec = 0;
+
+	ret = select(nfds, &readfds, NULL, NULL, &timeout);
+	if (ret < 0) {
+		sd_journal_print(LOG_ERR, "Unable to select (%d)", ret);
+		goto close;
+	} else if (ret == 0) {
+		sd_journal_print(LOG_ERR, "Timeout occurred");
+		ret = -ETIMEDOUT;
+		goto close;
+	}
+
+	while (reply_count < SHELL_CMD_REPLY_TLM_MAX_CNT) {
+		rsize = fread(result, 1, sizeof(result), fp);
+		if (rsize <= 0) {
+			if (reply_count == 0) {
+				strcpy(result, "No output");
+				send_cmd_reply(packet, command_id, rsize, (uint8_t *)result);
+				sd_journal_print(LOG_DEBUG, "Send reply (No output)");
+			}
+			break;
+		}
+		send_cmd_reply(packet, command_id, 0, (uint8_t *)result);
+		memset(result, 0, sizeof(result));
+		reply_count++;
+		sd_journal_print(LOG_DEBUG, "Send reply %d times", reply_count);
+		sleep(SHELL_CMD_REPLY_INTERVAL_SEC);
+	}
+
+close:
+	pclose(fp);
+
+end:
+	if (ret < 0) {
+		send_cmd_reply(packet, command_id, ret, NULL);
+	}
+
+	/*
+	 * Since the reply uses a clone for the response, the original is released manually.
+	 */
+	csp_buffer_free(packet);
+
+	return;
+}
+
+static void csp_shell_work(csp_packet_t *packet)
+{
+	int ret = 0;
+	uint8_t command_id;
+
+	if (packet == NULL) {
+		ret = -EINVAL;
+		command_id = CSP_UNKNOWN_COMMAND_ID;
+		goto end;
+	}
+
+	if (packet->length < SHELL_CMD_MIN_SIZE) {
+		sd_journal_print(LOG_ERR, "Invalide command size: %d", packet->length);
+		ret = -EINVAL;
+		command_id = CSP_UNKNOWN_COMMAND_ID;
+		goto reply;
+	}
+
+	command_id = packet->data[CSP_COMMAND_ID_OFFSET];
+
+	switch (command_id) {
+	case SHELL_CMD:
+		shell_cmd(command_id, packet);
+		break;
+	default:
+		sd_journal_print(LOG_ERR, "Unkown command code: %d", command_id);
+		ret = -EINVAL;
+		command_id = CSP_UNKNOWN_COMMAND_ID;
+		break;
+	}
+
+reply:
+	if (ret < 0) {
+		send_cmd_reply(packet, command_id, ret, NULL);
+	}
+
+end:
+	return;
+}
+
+static void *shell_work_thread(void *arg)
+{
+	csp_packet_t *packet;
+
+	ARG_UNUSED(arg);
+
+	while (true) {
+		packet = (csp_packet_t *)g_queue_pop_head(&shell_work_queue);
+		if (packet == NULL) {
+			sleep(SHELL_WORK_THREAD_SLEEP_SEC);
+			continue;
+		}
+		csp_shell_work(packet);
+	}
+
+	pthread_exit(NULL);
+}
+
+void shell_handler(csp_packet_t *packet)
+{
+	g_queue_push_tail(&shell_work_queue, packet);
+}
+
+void shell_handler_init(void)
+{
+	int ret;
+
+	g_queue_init(&shell_work_queue);
+
+	ret = pthread_create(&shell_work, NULL, shell_work_thread, NULL);
+	if (ret < 0) {
+		sd_journal_print(LOG_ERR, "Unable to create shell work thread");
+	} else {
+		sd_journal_print(LOG_INFO, "Start the shell work thread");
+	}
+}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/shell.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/shell.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Space Cubics, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <csp/csp.h>
+
+#define SHELL_RESULT_BUF_SIZE (240U)
+
+struct shell_err_reply_telemetry {
+	uint8_t telemetry_id;
+	uint32_t error_code;
+} __attribute__((__packed__));
+
+struct shell_cmd_reply_telemetry {
+	uint8_t telemetry_id;
+	uint32_t error_code;
+	uint8_t result[SHELL_RESULT_BUF_SIZE];
+} __attribute__((__packed__));
+
+void shell_handler_init(void);
+void shell_handler(csp_packet_t *packet);

--- a/zero/meta-libcsp/recipes-libcsp/files/0001-drivers-usart-Remove-exit-code-from-Linux-driver.patch
+++ b/zero/meta-libcsp/recipes-libcsp/files/0001-drivers-usart-Remove-exit-code-from-Linux-driver.patch
@@ -1,0 +1,39 @@
+From 90316c0f7fe41d1eac1d38d24b8d381c94d63466 Mon Sep 17 00:00:00 2001
+From: Takuya Sasaki <takuya.sasaki@spacecubics.com>
+Date: Wed, 20 Nov 2024 11:15:38 +0900
+Subject: [PATCH] drivers: usart: Remove exit() code from Linux driver
+
+The Linux USART driver for libcsp calls `exit()` API the rx_thread if
+a read operation fails. This behavior terminates the entire process,
+even if communication via interfaces other than USART is still possible.
+Therefore, the exit() code will be removed.
+
+Signed-off-by: Takuya Sasaki <takuya.sasaki@spacecubics.com>
+---
+ src/drivers/usart/usart_linux.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/drivers/usart/usart_linux.c b/src/drivers/usart/usart_linux.c
+index 48aa3d2..46d6539 100644
+--- a/src/drivers/usart/usart_linux.c
++++ b/src/drivers/usart/usart_linux.c
+@@ -38,7 +38,7 @@ static void * usart_rx_thread(void * arg) {
+ 	uint8_t * cbuf = malloc(CBUF_SIZE);
+ 	if (cbuf == NULL) {
+ 		csp_print("%s: malloc() failed, returned NULL\n", __func__);
+-		exit(1);
++		return NULL;
+ 	}
+ 
+ 	// Receive loop
+@@ -46,7 +46,7 @@ static void * usart_rx_thread(void * arg) {
+ 		int length = read(ctx->fd, cbuf, CBUF_SIZE);
+ 		if (length <= 0) {
+ 			csp_print("%s: read() failed, returned: %d\n", __func__, length);
+-			exit(1);
++			return NULL;
+ 		}
+ 		ctx->rx_callback(ctx->user_data, cbuf, length, NULL);
+ 	}
+-- 
+2.34.1

--- a/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
+++ b/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2915dc85ab8fd26629e560d023ef175c"
 SRCREV = "${AUTOREV}"
 SRCBRANCH = "develop"
 SRC_URI = "git://github.com/libcsp/libcsp.git;protocol=https;branch=${SRCBRANCH};"
+SRC_URI += "file://0001-drivers-usart-Remove-exit-code-from-Linux-driver.patch"
 
 DEPENDS += "libsocketcan"
 


### PR DESCRIPTION
For the firmware update of Zero and Pico, it is necessary to execute
commands like `rauc`, `mcumgr`, and crc32, which are already included
in out Yocto environment. These commands will be used for file
uploads, CRC calculation, and firmware update processes.
    
The commands can accept strings up to 200 bytes in length, and the
command responses will be split into 240 byte segments when downlinked.
However, to avoid infinite downlinking, a limit is set on the number
of responses (50 responses per command).
    
Additionally, to account for potential command hang-ups, the timeout
duration can also be specified from the Ground.
    
While we understand that security considerations are necessary, we have
not implemented any restrictions in the first commit.