### PR TITLE
zero: csp-handler: Add get version command handler

### DIFF
--- a/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
+++ b/zero/meta-csp/recipes-cspd/csp-handler/csp-handler_0.bb
@@ -21,6 +21,9 @@ SRC_URI = "file://main.c \
            file://upload.h \
            file://shell.c \
            file://shell.h \
+           file://system.c \
+           file://system.h \
+           file://version.h \
            file://cspd.h \
            file://Makefile \
            file://LICENSE"

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/Makefile
@@ -1,4 +1,4 @@
-SRCS := shell.c upload.c file.c hwtest.c camera.c temp.c handler.c router.c main.c
+SRCS := system.c shell.c upload.c file.c hwtest.c camera.c temp.c handler.c router.c main.c
 OBJS := $(SRCS:.c=.o)
 SYSTEMD_CFLAGS := $(shell pkg-config --cflags libsystemd)
 SYSTEMD_LIBS := $(shell pkg-config --libs libsystemd)

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/cspd.h
@@ -13,6 +13,7 @@
 #define PORT_SHELL  (10U) /* for shell command */
 #define PORT_HWTEST (11U) /* for HWTEST program */
 #define PORT_FILE   (13U) /* for file related command */
+#define PORT_SYSTEM (16U) /* For system related command */
 
 #define CSP_COMMAND_ID_OFFSET  (0U)
 #define CSP_UNKNOWN_COMMAND_ID (255U)

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/handler.c
@@ -13,6 +13,7 @@
 #include "hwtest.h"
 #include "file.h"
 #include "shell.h"
+#include "system.h"
 
 void *handle_csp_packet(void *param)
 {
@@ -38,6 +39,9 @@ void *handle_csp_packet(void *param)
 				break;
 			case PORT_FILE:
 				file_handler(packet);
+				break;
+			case PORT_SYSTEM:
+				system_handler(packet);
 				break;
 			default:
 				csp_service_handler(packet);

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/system.c
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/system.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Space Cubics, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#include "system.h"
+
+#include <systemd/sd-journal.h>
+#include <errno.h>
+#include "cspd.h"
+#include "version.h"
+
+/* Command size */
+#define SYSTEM_CMD_MIN_SIZE (1U)
+
+/* Command ID */
+#define SYSTEM_GET_VER_CMD (0U)
+
+static void send_system_err_reply(csp_packet_t *packet, uint8_t command_id, int err_code)
+{
+	struct system_err_telemetry tlm;
+
+	tlm.telemetry_id = command_id;
+	tlm.error_code = htole32(err_code);
+
+	memcpy(packet->data, &tlm, sizeof(tlm));
+	packet->length = sizeof(tlm);
+
+	csp_sendto_reply(packet, packet, CSP_O_SAME);
+}
+
+static void send_system_version_reply(csp_packet_t *packet, uint8_t command_id, int err_code)
+{
+	struct system_version_telemetry tlm;
+
+	tlm.telemetry_id = command_id;
+	tlm.error_code = htole32(err_code);
+	strcpy(tlm.version, CSPD_VERSION);
+
+	memcpy(packet->data, &tlm, sizeof(tlm));
+	packet->length = sizeof(tlm);
+
+	csp_sendto_reply(packet, packet, CSP_O_SAME);
+}
+
+void system_handler(csp_packet_t *packet)
+{
+	int ret = 0;
+	uint8_t command_id;
+
+	if (packet == NULL) {
+		command_id = CSP_UNKNOWN_COMMAND_ID;
+		goto end;
+	}
+
+	if (packet->length < SYSTEM_CMD_MIN_SIZE) {
+		sd_journal_print(LOG_ERR, "Invalide command size: %d", packet->length);
+		ret = -EINVAL;
+		command_id = CSP_UNKNOWN_COMMAND_ID;
+		goto reply;
+	}
+
+	command_id = packet->data[CSP_COMMAND_ID_OFFSET];
+
+	switch (command_id) {
+	case SYSTEM_GET_VER_CMD:
+		send_system_version_reply(packet, command_id, 0);
+		break;
+	default:
+		sd_journal_print(LOG_ERR, "Unkown command code: %d", command_id);
+		ret = -EINVAL;
+		command_id = CSP_UNKNOWN_COMMAND_ID;
+		break;
+	}
+
+reply:
+	if (ret < 0) {
+		send_system_err_reply(packet, command_id, ret);
+	}
+
+end:
+	return;
+}

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/system.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/system.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Space Cubics, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <csp/csp.h>
+
+#define SYSTEM_VERSION_STR_SIZE (16U)
+
+struct system_err_telemetry {
+	uint8_t telemetry_id;
+	uint32_t error_code;
+} __attribute__((__packed__));
+
+struct system_version_telemetry {
+	uint8_t telemetry_id;
+	uint32_t error_code;
+	char version[SYSTEM_VERSION_STR_SIZE];
+} __attribute__((__packed__));
+
+void system_handler(csp_packet_t *packet);

--- a/zero/meta-csp/recipes-cspd/csp-handler/files/version.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/version.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Space Cubics, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#define CSPD_VERSION "0.3.0"


### PR DESCRIPTION
Adds the getting version command handler. Currently, it only returns a hard-coded version string. Additionally, the port number uses Port `16`, the same as the command for getting system-related information from the MAIN/ADCS board.