### PR TITLE
zero: csp-handler: Fix missing error telemetry

### DIFF
--- a/zero/meta-csp/recipes-cspd/csp-handler/files/file.h
+++ b/zero/meta-csp/recipes-cspd/csp-handler/files/file.h
@@ -8,5 +8,10 @@
 
 #include <csp/csp.h>
 
+struct file_err_reply_telemetry {
+	uint8_t telemetry_id;
+	uint32_t error_code;
+} __attribute__((__packed__));
+
 void file_handler_init(void);
 void file_handler(csp_packet_t *packet);


### PR DESCRIPTION
Fixes an issue where reply telemetry was not returned for file-related commands with invalid sizes or command IDs.