### PR TITLE
zero: libcsp: Lock revision

### DIFF
--- a/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
+++ b/zero/meta-libcsp/recipes-libcsp/libcsp_0.bb
@@ -3,6 +3,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2915dc85ab8fd26629e560d023ef175c"
 
 SRCREV = "${AUTOREV}"
 SRCBRANCH = "develop"
+SRCREV = "1653d5b340cdf97ceb97dbf84b2dcbbfe8623e8c"
 SRC_URI = "git://github.com/libcsp/libcsp.git;protocol=https;branch=${SRCBRANCH};"
 SRC_URI += "file://0001-drivers-usart-Remove-exit-code-from-Linux-driver.patch"
 


### PR DESCRIPTION
This commit locks the revision of libcsp for the Zero, just like it has been done for the MAIN/ADCS board and Pico by same revision.