### PR TITLE
pico: Return status code for temp command

### DIFF
--- a/pico/src/pico_csp.c
+++ b/pico/src/pico_csp.c
@@ -93,7 +93,7 @@ static void server(void)
 					LOG_ERR("Failed to get temperature");
 					csp_buffer_free(packet);
 				} else {
-					LOG_DBG("Temperature: %.2f℃", (double)temp);
+					LOG_DBG("Temperature: %.2f celsius", (double)temp);
 					memcpy(packet->data, &temp, sizeof(temp));
 					packet->length = sizeof(temp);
 					csp_send(conn, packet);

--- a/pico/src/pico_csp.c
+++ b/pico/src/pico_csp.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <csp/csp.h>
 #include <csp/drivers/usart.h>
+#include <math.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(csp, CONFIG_MAIN_LOG_LEVEL);
@@ -88,16 +89,20 @@ static void server(void)
 			switch (csp_conn_dport(conn)) {
 			case PORT_T:
 				float temp;
+				int8_t status;
 				int result = get_temp(&temp);
 				if (result < 0) {
 					LOG_ERR("Failed to get temperature");
-					csp_buffer_free(packet);
+					temp = NAN;
+					status = -1;
 				} else {
 					LOG_DBG("Temperature: %.2f celsius", (double)temp);
-					memcpy(packet->data, &temp, sizeof(temp));
-					packet->length = sizeof(temp);
-					csp_send(conn, packet);
+					status = 0;
 				}
+				packet->data[0] = status;
+				memcpy(packet->data + 1, &temp, sizeof(temp));
+				packet->length = 1 + sizeof(temp);
+				csp_send(conn, packet);
 			default:
 				csp_service_handler(packet);
 				break;


### PR DESCRIPTION
This PR has two commits. The main one is to always return a status code for temperature command.

The other is to remove non-ASCII char.

Pleas check the commit log for more detail.